### PR TITLE
Enable ChipsInputTextChangedListener and android:textAppearance

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ allprojects {
 In your app level build.gradle:
 ```java
 dependencies {
-    compile 'com.github.tylersuehr7:chips-input-layout:2.0'
+    compile 'com.github.tylersuehr7:chips-input-layout:2.2'
 }  
 ```
 

--- a/library/src/main/java/com/tylersuehr/chips/ChipOptions.java
+++ b/library/src/main/java/com/tylersuehr/chips/ChipOptions.java
@@ -40,6 +40,8 @@ final class ChipOptions {
     ColorStateList mFilterableListTextColor;
     float mFilterableListElevation;
 
+    int mTextAppearanceIdRes;
+
     /* Properties pertaining to the ChipsInputLayout itself */
     Typeface mTypeface = Typeface.DEFAULT;
     boolean mAllowCustomChips;
@@ -50,7 +52,7 @@ final class ChipOptions {
     ChipImageRenderer mImageRenderer;
 
 
-    ChipOptions(Context c, AttributeSet attrs) {
+    ChipOptions(Context c, AttributeSet attrs, int defStyleAttr) {
         TypedArray a = c.obtainStyledAttributes(attrs, R.styleable.ChipsInputLayout);
 
         // Setup the properties for the ChipEditText
@@ -83,6 +85,12 @@ final class ChipOptions {
         mMaxRows = a.getInt(R.styleable.ChipsInputLayout_maxRows, 3);
 
         a.recycle();
+
+        final int[] styleable = new int[] { android.R.attr.textAppearance };
+
+        TypedArray ta = c.obtainStyledAttributes(attrs, styleable, defStyleAttr, 0);
+        mTextAppearanceIdRes = ta.getResourceId(0, android.R.attr.textAppearanceMedium);
+        ta.recycle();
 
         mImageRenderer = new DefaultImageRenderer();
     }

--- a/library/src/main/java/com/tylersuehr/chips/ChipsEditText.java
+++ b/library/src/main/java/com/tylersuehr/chips/ChipsEditText.java
@@ -74,6 +74,7 @@ class ChipsEditText extends AppCompatEditText implements ChipComponent {
         }
         setHint(options.mHint);
         setTypeface(options.mTypeface);
+        setTextAppearance(getContext(), options.mTextAppearanceIdRes);
     }
 
     float calculateTextWidth() {

--- a/library/src/main/java/com/tylersuehr/chips/ChipsInputLayout.java
+++ b/library/src/main/java/com/tylersuehr/chips/ChipsInputLayout.java
@@ -48,6 +48,7 @@ public class ChipsInputLayout extends MaxHeightScrollView
     /* Displays filtered chips */
     private FilterableRecyclerView mFilteredRecycler;
     private FilterableChipsAdapter mFilteredAdapter;
+    private ChipsInputTextChangedListener mTextChangedListener;
 
     /* Used to validate selected chips */
     private ChipValidator mValidator;
@@ -58,8 +59,12 @@ public class ChipsInputLayout extends MaxHeightScrollView
     }
 
     public ChipsInputLayout(Context c, AttributeSet attrs) {
-        super(c, attrs);
-        mOptions = new ChipOptions(c, attrs);
+        this(c, attrs);
+    }
+
+    public ChipsInputLayout(Context c, AttributeSet attrs, int defStyleAttr) {
+        super(c, attrs, defStyleAttr);
+        mOptions = new ChipOptions(c, attrs, defStyleAttr);
         mDataSource = new ListChipDataSource();
 
         // Inflate the view
@@ -452,6 +457,10 @@ public class ChipsInputLayout extends MaxHeightScrollView
         return LetterTileProvider.getInstance(getContext());
     }
 
+    public void setInputTextChangedListener(ChipsInputTextChangedListener listener) {
+        mTextChangedListener = listener;
+    }
+
     public void setInputTextColor(ColorStateList textColor) {
         mOptions.mTextColor = textColor;
         if (mChipsInput != null) { // Can be null because its lazy loaded
@@ -636,6 +645,17 @@ public class ChipsInputLayout extends MaxHeightScrollView
         public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
 
         @Override
-        public void afterTextChanged(Editable s) {}
+        public void afterTextChanged(Editable s) {
+            if (mTextChangedListener != null) {
+                mTextChangedListener.onTextChangedListener(s);
+                // TODO: As this is a listener used mostly to dinamically change the filteredList, a 
+                // timeout before filtering should be configured to replace 1500(ms) hardcoded value
+                new Handler().postDelayed(() -> onTextChanged(s, 0, 0, 0), 1500);
+            }
+        }
+    }
+
+    public interface ChipsInputTextChangedListener {
+        void onChipsInputTextChanged (CharSequence s);
     }
 }

--- a/library/src/main/java/com/tylersuehr/chips/ChipsInputLayout.java
+++ b/library/src/main/java/com/tylersuehr/chips/ChipsInputLayout.java
@@ -59,7 +59,7 @@ public class ChipsInputLayout extends MaxHeightScrollView
     }
 
     public ChipsInputLayout(Context c, AttributeSet attrs) {
-        this(c, attrs);
+        this(c, attrs, 0);
     }
 
     public ChipsInputLayout(Context c, AttributeSet attrs, int defStyleAttr) {

--- a/library/src/main/java/com/tylersuehr/chips/FilterableChipsAdapter.java
+++ b/library/src/main/java/com/tylersuehr/chips/FilterableChipsAdapter.java
@@ -123,12 +123,15 @@ class FilterableChipsAdapter
             // TODO: POSSIBLE OPTIMIZATION
             // Have takeChip(int) return a Chip object; which can be null checked for callback
 
-            // Take the chip from the filtered chip list
-            final Chip chip = mDataSource.getFilteredChip(getAdapterPosition());
-            mDataSource.takeChip(chip);
+            int index = getAdapterPosition();
+            if (index >= 0 && index < getItemCount()) {
+                // Take the chip from the filtered chip list
+                final Chip chip = mDataSource.getFilteredChip(getAdapterPosition());
+                mDataSource.takeChip(chip);
 
-            // Trigger callback with the clicked chip
-            mListener.onFilteredChipClick(chip);
+                // Trigger callback with the clicked chip
+                mListener.onFilteredChipClick(chip);
+            }
         }
     }
 

--- a/library/src/main/java/com/tylersuehr/chips/MaxHeightScrollView.java
+++ b/library/src/main/java/com/tylersuehr/chips/MaxHeightScrollView.java
@@ -22,7 +22,11 @@ public class MaxHeightScrollView extends NestedScrollView {
     }
 
     public MaxHeightScrollView(Context c, AttributeSet attrs) {
-        super(c, attrs);
+        this(c, attrs, 0);
+    }
+
+    public MaxHeightScrollView(Context c, AttributeSet attrs, int defStyleAttr) {
+        super(c, attrs, defStyleAttr);
         TypedArray a = c.obtainStyledAttributes(attrs, R.styleable.MaxHeightScrollView);
         this.mMaxHeight = a.getDimensionPixelSize(R.styleable.MaxHeightScrollView_android_maxHeight, Utils.dp(300));
         a.recycle();


### PR DESCRIPTION
- FilterableChipsAdapter: Fixed a bug that threw an `ArrayOutOfBoundsException`, after clicking a non-existing chip.
- ChipOptions/MaxHeightScrollView/ChipsEditText: Allowed setting `android:textAppearance` attribute via XML.
- ChipsInputLayout: Added `ChipsInputTextChangedListener`, that allows to get the input text and modify the filteredList.